### PR TITLE
expose AccessToken method

### DIFF
--- a/android/src/facebook/TiFacebookModule.java
+++ b/android/src/facebook/TiFacebookModule.java
@@ -402,7 +402,7 @@ public class TiFacebookModule extends KrollModule
 		return uid;
 	}
 
-	@Kroll.getProperty
+	@Kroll.getProperty @Kroll.method
 	public String getAccessToken() {
 		Log.d(TAG, "get accessToken");
 		return Session.getActiveSession().getAccessToken();


### PR DESCRIPTION
The getAccessToken function was throwing an error because the method wasn't exposed in the class with the @Kroll.method.
