### PR TITLE
won't compile unless this pull request is accepted

### DIFF
--- a/ios/titanium.xcconfig
+++ b/ios/titanium.xcconfig
@@ -10,7 +10,7 @@ TITANIUM_SDK_VERSION = 4.0.0
 //
 // THESE SHOULD BE OK GENERALLY AS-IS
 //
-TITANIUM_SDK = ~/Library/Application Support/Titanium/mobilesdk/osx/4.0.0
+TITANIUM_SDK = ~/Library/Application Support/Titanium/mobilesdk/osx/4.0.0.GA
 TITANIUM_BASE_SDK = "$(TITANIUM_SDK)/iphone/include"
 TITANIUM_BASE_SDK2 = "$(TITANIUM_SDK)/iphone/include/TiCore"
 HEADER_SEARCH_PATHS= $(TITANIUM_BASE_SDK) $(TITANIUM_BASE_SDK2)


### PR DESCRIPTION
```
➜  Desktop  git clone https://github.com/appcelerator-modules/ti.facebook.git
Cloning into 'ti.facebook'...
remote: Counting objects: 1667, done.
remote: Total 1667 (delta 0), reused 0 (delta 0), pack-reused 1667
Receiving objects: 100% (1667/1667), 114.58 MiB | 5.19 MiB/s, done.
Resolving deltas: 100% (811/811), done.
Checking connectivity... done.
➜  Desktop  cd ti.facebook
➜  ti.facebook git:(master) open .
➜  ti.facebook git:(master) ls
History.md    README.md     apidoc        documentation ios
LICENSE       android       assets        example
➜  ti.facebook git:(master) ✗ cd ios
➜  ios git:(master) ✗ ./build.py
Traceback (most recent call last):
  File "./build.py", line 242, in <module>
    build_module(manifest,config)
  File "./build.py", line 171, in build_module
    from tools import ensure_dev_path
ImportError: No module named tools
```

This fixes the issue I just pointed out.
