### PR TITLE
[TC-5832] [TC-5564] Android: Install statistics does not arrive to FB as expected IOS: FacebookModule::logCustomEvent crashes on iOS

### DIFF
--- a/android/src/facebook/TiFacebookModule.java
+++ b/android/src/facebook/TiFacebookModule.java
@@ -115,6 +115,21 @@ public class TiFacebookModule extends KrollModule implements OnActivityResultEve
 	public static TiFacebookModule getFacebookModule() {
 		return module;
 	}
+    
+    @Override
+    public void onResume(Activity activity) {
+        super.onResume(activity);
+        Log.d(TAG, "Calling activateApp");
+        AppEventsLogger.activateApp(activity);
+        AppEventsLogger.flush();
+    }
+    
+    @Override
+    public void onPause(Activity activity) {
+        super.onPause(activity);
+        Log.d(TAG, "Calling deactivateApp");
+        AppEventsLogger.deactivateApp(activity);
+    }
 
 	public CallbackManager getCallbackManager() {
 		return callbackManager;

--- a/android/src/facebook/TiFacebookModule.java
+++ b/android/src/facebook/TiFacebookModule.java
@@ -121,7 +121,6 @@ public class TiFacebookModule extends KrollModule implements OnActivityResultEve
         super.onResume(activity);
         Log.d(TAG, "Calling activateApp");
         AppEventsLogger.activateApp(activity);
-        AppEventsLogger.flush();
     }
     
     @Override

--- a/ios/Classes/FacebookModule.m
+++ b/ios/Classes/FacebookModule.m
@@ -282,8 +282,7 @@ NSDictionary *launchOptions = nil;
 -(void)logCustomEvent:(id)event
 {
     ENSURE_SINGLE_ARG(event, NSString);
-    //NSString* event = [args objectAtIndex:0];
-    [FBSDKAppEvents logEvent:event];
+    [FBSDKAppEvents logEvent:[TiUtils stringValue:event]];
 }
 
 /**

--- a/ios/Classes/FacebookModule.m
+++ b/ios/Classes/FacebookModule.m
@@ -279,10 +279,10 @@ NSDictionary *launchOptions = nil;
  * facebook.logCustomEvent('clappedHands');
  *
  */
--(void)logCustomEvent:(id)args
+-(void)logCustomEvent:(id)event
 {
-    ENSURE_SINGLE_ARG(args, NSString);
-    NSString* event = [args objectAtIndex:0];
+    ENSURE_SINGLE_ARG(event, NSString);
+    //NSString* event = [args objectAtIndex:0];
     [FBSDKAppEvents logEvent:event];
 }
 


### PR DESCRIPTION
AppEvents for tracking installs are not being set up as per Facebook SDK docs, that's the reference guide: https://developers.facebook.com/docs/app-ads/sdk#install-tracking
