### PR TITLE
[TIMOB-23596] Android: Recompile ti.facebook module against latest SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 language: objective-c
-osx_image: xcode7.1
+osx_image: xcode7.3
 env:
 global:
     - "MODULE_NAME=facebook"
 before_install:
     - MODULE_ROOT=$PWD
+    - brew update
+    - brew install nvm
+    - source $(brew --prefix nvm)/nvm.sh
+    - nvm install 4
+    - npm config delete prefix
+    - nvm use --delete-prefix v4.4.7 4
 install:
     - cd $MODULE_ROOT
-    - curl -o install.sh https://raw.githubusercontent.com/appcelerator-modules/ci/master/travis/install.sh
-    - source install.sh -s "--branch 5_1_X"
-script: 
-    - curl -o script.sh https://raw.githubusercontent.com/appcelerator-modules/ci/master/travis/script.sh
+    - curl -o install.sh https://raw.githubusercontent.com/sgtcoolguy/ci/v8/travis/install.sh #change this to appcelerator-modules once PR has been merged
+    - source install.sh -s "--branch master"
+script:
+    - curl -o script.sh https://raw.githubusercontent.com/sgtcoolguy/ci/v8/travis/script.sh
     - source script.sh
 after_success: # and this only on success
     - curl -o deploy.sh https://raw.githubusercontent.com/appcelerator-modules/ci/master/travis/deploy.sh

--- a/android/manifest
+++ b/android/manifest
@@ -2,9 +2,9 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.2.0
-apiversion: 2
-architectures: armeabi armeabi-v7a x86
+version: 6.0.0
+apiversion: 3
+architectures: armeabi-v7a x86
 description: facebook
 author: Mark Mokryn and Ashraf A. S. (Appcelerator)
 license: Apache License Version 2.0
@@ -16,4 +16,4 @@ name: Facebook
 moduleid: facebook
 guid: e4f7ac61-1ee7-44c5-bc27-fa6876e2dce9
 platform: android
-minsdk: 5.0.0.GA
+minsdk: 6.0.0


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-23596

Relates to appcelerator-modules/ti.map#167

Updates version, apiversion and minsdk (version). Removes the armeabi ABI, since V8 doesn't officially support that (armeabi-v7a should be OK).
