### PR TITLE
Fixed Typo

### DIFF
--- a/ios/Classes/FacebookModule.m
+++ b/ios/Classes/FacebookModule.m
@@ -262,7 +262,7 @@ NSDictionary *launchOptions = nil;
     return [NSNumber numberWithUnsignedInteger:FBSDKLoginBehaviorNative];
 }
 
--(id)LOGIN_BEHAVIOR_SYTEM_ACCOUNT
+-(id)LOGIN_BEHAVIOR_SYSTEM_ACCOUNT
 {
     return [NSNumber numberWithUnsignedInteger:FBSDKLoginBehaviorSystemAccount];
 }


### PR DESCRIPTION
The Login Behaviour Constant had a typo. Fixed "SYSTEM" to match README & Facebook SDK docs.
