### PR TITLE
Fixed Facebook.yml

### DIFF
--- a/apidoc/Facebook.yml
+++ b/apidoc/Facebook.yml
@@ -1961,7 +1961,6 @@ properties:
     type: String
     since: "5.0.0"
     deprecated:
-    deprecated:
         since: "6.2.0"
         removed: "6.2.0"
         notes: |
@@ -1972,7 +1971,6 @@ properties:
   - name: picture
     summary: Link to a thumbnail to associate with the link.
     type: String
-    deprecated:
     deprecated:
         since: "6.2.0"
         removed: "6.2.0"


### PR DESCRIPTION
Found an empty deprecate in the title and pictures attributes of ShareLinkContentParams module as noted in https://jira.appcelerator.org/browse/TIDOC-3178