### PR TITLE
Update links to official facebook documentation

### DIFF
--- a/apidoc/LikeButton.yml
+++ b/apidoc/LikeButton.yml
@@ -21,8 +21,8 @@ description: |
     on iOS or Android, don't collect or use any information from it.
     </blockquote>
 
-    See the [official Facebook Like Button documentation for Android](https://developers.facebook.com/docs/android/like-button)
-    or the [official Facebook Like Button documentation for iOS](https://developers.facebook.com/docs/ios/like-button)
+    See the [official Facebook Sharing documentation for Android](https://developers.facebook.com/docs/sharing/android)
+    or the [official Facebook Sharing documentation for iOS](https://developers.facebook.com/docs/sharing/ios)
     for more information.
 
     #### Android Platform Notes


### PR DESCRIPTION
Update links to facebook documentation as the previous one for iOS was broken and for android it opens up to older facebook SDk page and is deprecated.