### PR TITLE
test: use 9.0.0.GA by default

### DIFF
--- a/test/unit/karma.unit.config.js
+++ b/test/unit/karma.unit.config.js
@@ -49,7 +49,7 @@ module.exports = config => {
 			}
 		],
 		titanium: {
-			sdkVersion: config.sdkVersion || '8.1.0.GA'
+			sdkVersion: config.sdkVersion || '9.0.0.GA'
 		},
 		customLaunchers: {
 			android: {


### PR DESCRIPTION
Module is being built with 8.1.0.GA, but module is moved to gradle so that's maybe why it's failing to build.
It looks like Jenkins passes in the sdk version with the command `npm run test:android -- --sdkVersion 9.0.0.v20200127103011` so that's why it's fine in Jenkins.