### PR TITLE
feat(android) update to Facebook SDK 13.1.0, remove deprecated game request

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,5 +6,5 @@ buildscript {
 }
 
 dependencies {
-	implementation 'com.facebook.android:facebook-android-sdk:11.1.1'
+	implementation 'com.facebook.android:facebook-android-sdk:12.0.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,5 +6,5 @@ buildscript {
 }
 
 dependencies {
-	implementation 'com.facebook.android:facebook-android-sdk:12.0.0'
+	implementation 'com.facebook.android:facebook-android-sdk:13.1.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,5 +6,5 @@ buildscript {
 }
 
 dependencies {
-	implementation 'com.facebook.android:facebook-android-sdk:9.0.0'
+	implementation 'com.facebook.android:facebook-android-sdk:11.1.1'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 11.0.2
+version: 11.1.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: facebook

--- a/apidoc/Facebook.yml
+++ b/apidoc/Facebook.yml
@@ -282,40 +282,6 @@ description: |
     For details on the Share dialog, see the
     [official Facebook Share Dialogs documentation](https://developers.facebook.com/docs/sharing/reference/share-dialog).
 
-    ### Game Requests Dialog
-
-    To send a game request to a user, call the
-    [presentSendRequestDialog()](Modules.Facebook.presentSendRequestDialog) method and pass the
-    method a dictionary with the `message` property set the message you want to send the invited user.
-    Optional: You can set the `title` property with a title string. You can also set the `data` property
-    with a dictionary of custom parameters. If you want to preselect users to send invite to, you can set
-    the `to` property with string of values that are facebook ids seperated by comma.
-
-    To monitor if the request succeeded or not, listen to the <Modules.Facebook.requestDialogCompleted> event.
-
-    ``` javascript
-    fb.addEventListener('requestDialogCompleted', function (e) {
-        if (e.success) {
-            Ti.API.info('request succeeded.');
-        } else {
-            Ti.API.warn('Failed to share.');
-        }
-    });
-
-    fb.presentSendRequestDialog({
-        message: 'Go to https://appcelerator.com/',
-        title: 'Invitation to Appcelerator',
-        recipients: ['123456789', '987654321'],
-        data: {
-            badge_of_awesomeness: '1',
-            social_karma: '5'
-        }
-    });
-    ```
-
-    For details on game request dialogs see the
-    [official Facebook Request Dialogs documentation](https://developers.facebook.com/docs/games/services/gamerequests).
-
     ### Messenger Button
 
     The Messenger button provides a quick mechanism for users to share content to the Facebook Messenger.
@@ -490,19 +456,6 @@ methods:
         summary: A dictionary object containing the required and optional parameters.
         type: SharePhotoContentParams
     since: "7.4.0"
-
-  - name: presentSendRequestDialog
-    summary: |
-        Opens an App Request dialog.
-    description: |
-        A `requestDialogCompleted` event is generated to indicate if the request attempt was successful or unsuccessful,
-        and the resultURL.
-    parameters:
-      - name: params
-        summary: |
-            A dictionary object containing parameters.
-        type: RequestDialogParams
-    since: "4.0.0"
 
   - name: refreshPermissionsFromServer
     summary: Makes a request to Facebook to get the latest permissions granted.

--- a/test/unit/specs/module.spec.js
+++ b/test/unit/specs/module.spec.js
@@ -408,12 +408,6 @@ describe('ti.facebook', () => {
 				});
 			});
 
-			describe('#presentSendRequestDialog(params)', () => {
-				it('is a function', () => {
-					expect(Facebook.presentSendRequestDialog).toEqual(jasmine.any(Function));
-				});
-			});
-
 			describe('#presentShareDialog(params)', () => {
 				it('is a function', () => {
 					expect(Facebook.presentShareDialog).toEqual(jasmine.any(Function));


### PR DESCRIPTION
* Updates Facebook SDK to  12.0.0 (fixes Android 12 issues!)
* removes deprecated Game request dialog
* sets default `loginBehavior` to `LoginBehavior.NATIVE_WITH_FALLBACK` to remove a crash after login

[facebook-android-11.1.0.zip](https://github.com/tidev/ti.facebook/files/8353288/facebook-android-11.1.0.zip)

