### PR TITLE
Point the docs regen at titaniumsdk.com

### DIFF
--- a/.github/workflows/regen-docs.yml
+++ b/.github/workflows/regen-docs.yml
@@ -1,39 +1,35 @@
 name: Regen Docs
+
+# Tells titaniumsdk.com to recompile this module's API docs.
+#
+# Fires on a change to apidoc/ and on a published release, rather than on every
+# merged pull request, so a direct push to the default branch is not missed.
 on:
-  workflow_dispatch:
-  pull_request:
-    types: [ closed ]
-    branches: [ master ]
-    paths: [ 'apidoc/**' ]
+  push:
+    branches: [master]
+    paths: ['apidoc/**']
+  release:
+    types: [published]
 
 jobs:
-  regen:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+  lint:
     runs-on: ubuntu-latest
-    name: Trigger Regen
-
+    name: Lint
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v6
 
-    - name: Setup node
-      uses: actions/setup-node@v6
-      with:
-        node-version: '24'
-        registry-url: 'https://registry.npmjs.org'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
 
-    - name: Install dependencies
-      run: npm ci
-      if: steps.node-cache.outputs.cache-hit != 'true'
+      - run: npm ci
+      - run: npm run lint:docs
 
-    - run: npm run lint:docs
-      name: Lint
-      
-    - name: Repository Dispatch
-      uses: peter-evans/repository-dispatch@v2
-      with:
-        event-type: regen-api-docs
-        token: ${{ secrets.REGEN_DOCS_GITHUB_TOKEN }}
-        repository: tidev/titanium-docs
+  # The dispatch itself lives in titanium-www so the payload shape is defined
+  # once for all 17 source repos instead of copied into each.
+  notify:
+    needs: lint
+    uses: tidev/titanium-www/.github/workflows/notify-api-docs.yml@main
+    secrets:
+      dispatch-token: ${{ secrets.REGEN_DOCS_GITHUB_TOKEN }}

--- a/.github/workflows/regen-docs.yml
+++ b/.github/workflows/regen-docs.yml
@@ -32,9 +32,14 @@ jobs:
   # The dispatch itself lives in titanium-www so the payload shape is defined
   # once for all 17 source repos instead of copied into each.
   #
+  # Deliberately independent of the lint job. Gating the dispatch on it means an
+  # unrelated tooling problem stops the docs updating and nothing says so --
+  # ti.coremotion cannot run `npm ci` at all today because its lockfile is out of
+  # sync with its package.json. Genuinely malformed apidoc still cannot ship: the
+  # compile in titanium-www fails on it and commits nothing.
+  #
   # Skipped on pull_request: a proposed change gets linted, not published.
   notify:
-    needs: lint
     if: github.event_name != 'pull_request'
     uses: tidev/titanium-www/.github/workflows/notify-api-docs.yml@main
     secrets:

--- a/.github/workflows/regen-docs.yml
+++ b/.github/workflows/regen-docs.yml
@@ -3,8 +3,11 @@ name: Regen Docs
 # Tells titaniumsdk.com to recompile this module's API docs.
 #
 # Fires on a change to apidoc/ and on a published release, rather than on every
-# merged pull request, so a direct push to the default branch is not missed.
+# merged pull request, so a direct push to master is not missed.
 on:
+  workflow_dispatch:
+  pull_request:
+    paths: ['apidoc/**']
   push:
     branches: [master]
     paths: ['apidoc/**']
@@ -28,8 +31,11 @@ jobs:
 
   # The dispatch itself lives in titanium-www so the payload shape is defined
   # once for all 17 source repos instead of copied into each.
+  #
+  # Skipped on pull_request: a proposed change gets linted, not published.
   notify:
     needs: lint
+    if: github.event_name != 'pull_request'
     uses: tidev/titanium-www/.github/workflows/notify-api-docs.yml@main
     secrets:
       dispatch-token: ${{ secrets.REGEN_DOCS_GITHUB_TOKEN }}

--- a/.github/workflows/regen-docs.yml
+++ b/.github/workflows/regen-docs.yml
@@ -1,6 +1,6 @@
 name: Regen Docs
 
-# Tells titaniumsdk.com to recompile this module's API docs.
+# Tells the docs sites to recompile this module's API docs.
 #
 # Fires on a change to apidoc/ and on a published release, rather than on every
 # merged pull request, so a direct push to master is not missed.
@@ -29,8 +29,8 @@ jobs:
       - run: npm ci
       - run: npm run lint:docs
 
-  # The dispatch itself lives in titanium-www so the payload shape is defined
-  # once for all 17 source repos instead of copied into each.
+  # titaniumsdk.com. The dispatch lives in titanium-www so the payload shape is
+  # defined once for all 17 source repos instead of copied into each.
   #
   # Deliberately independent of the lint job. Gating the dispatch on it means an
   # unrelated tooling problem stops the docs updating and nothing says so --
@@ -44,3 +44,20 @@ jobs:
     uses: tidev/titanium-www/.github/workflows/notify-api-docs.yml@main
     secrets:
       dispatch-token: ${{ secrets.REGEN_DOCS_GITHUB_TOKEN }}
+
+  # The old pipeline, kept running alongside the new one so the site currently
+  # being served stays current while the replacement is proven. It carries no
+  # payload because titanium-docs does not read one -- it rebuilds every source
+  # repo on any dispatch, which is the inefficiency titanium-www replaces.
+  #
+  # Delete this job once titaniumsdk.com is served from titanium-www (TI-52).
+  notify-legacy:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    name: Notify titanium-docs (legacy)
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: regen-api-docs
+          repository: tidev/titanium-docs
+          token: ${{ secrets.REGEN_DOCS_GITHUB_TOKEN }}


### PR DESCRIPTION
Part of the titaniumsdk.com rebuild. The API docs pipeline gains a second destination, `tidev/titanium-www`, while the existing one keeps running.

### What changes

- **Adds** a dispatch to `tidev/titanium-www` carrying this repo's name in the payload. The existing dispatch sent nothing, so the regen had to check out all 17 source repos at full history on every trigger to work out what had changed. The new one fetches only this repo, shallow, sparse to `apidoc/`.
- **Keeps** the existing dispatch to `tidev/titanium-docs`, unchanged, as a second job. Both pipelines run in parallel so the site being served today stays current while the replacement is proven; backing out is merging a revert.
- Fires on a push touching `apidoc/**` and on a published release, rather than only on a merged pull request — a direct push is no longer missed.
- The new dispatch lives in a reusable workflow in `titanium-www`, so the payload shape is defined once for all 17 source repos rather than copied into each.

### Why `notify` does not depend on `lint`

Gating the dispatch on the lint job means an unrelated tooling problem stops the docs updating and nothing says so. `ti.coremotion` cannot run `npm ci` at all today — its lockfile is out of sync with its `package.json` — and with the gate in place its docs would silently never regenerate.

Malformed apidoc still cannot ship: the compile in `titanium-www` fails on unresolved references and schema violations and commits nothing, which is the right place for that check since it can see the whole corpus.

### Cleanups

- `fetch-depth: 0` removed — a lint does not need full history.
- `if: steps.node-cache.outputs.cache-hit != 'true'` removed; there is no `node-cache` step in this file, so the condition never did anything. Replaced with real npm caching.
- Node moves to 24. Verified `npm ci` and `lint:docs` on a current Node against repos previously pinned to 16.
- Adds a `pull_request` trigger so `apidoc/` changes get linted before merge. `notify` is skipped on pull requests — a proposed change gets linted, not published.
